### PR TITLE
added testing framework and initial tests.

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(traits)
+
+test_check("traits")

--- a/tests/testthat/test-betydb.R
+++ b/tests/testthat/test-betydb.R
@@ -1,0 +1,14 @@
+context("BETYdb")
+
+test_that("BETYdb API works", {
+  ## gh-18
+  get.out <- GET("https://www.betydb.org/priors.json") # Priors is a small table
+  expect_is(get.out, "response")
+})
+
+test_that("Genus / Species queries work", {
+  mxg <- betydb_traits(genus = 'Miscanthus', species = "giganteus", user = "ropensci-traits", pwd = "ropensci")
+  pavi <- betydb_traits(genus = 'Panicum', species = "virgatum", user = "ropensci-traits", pwd = "ropensci")
+  # expect_false(mxg == pavi)
+}
+)


### PR DESCRIPTION
* **important** these tests depend on the changes in function names from bety to betydb in gh-19
* tests the BETYdb API with `httr::GET`
* fixing gh-21 will enable the test for genus/species queries (currently commented out)