### PR TITLE
eol traitbank updated to reflect current API results

### DIFF
--- a/tests/testthat/helper-traits.R
+++ b/tests/testthat/helper-traits.R
@@ -4,3 +4,10 @@ check_betydb <- function(url){
     skip("Betydb is offline.")
   }
 }
+
+## only run if eol.org is up
+check_traitbank <- function(url){
+  if (httr::status_code(httr::GET("http://eol.org/api")) != 200) {
+    skip("eol's traitbank is offline.")
+  }
+}

--- a/tests/testthat/test-traitbank.R
+++ b/tests/testthat/test-traitbank.R
@@ -1,0 +1,36 @@
+context("eol's traitbank tests")
+
+tbtest_df <- data.frame(
+  sciname = c("Balaenoptera musculus", "Poa annua", "Closterocerus formosus"),
+  pageid = c(328574, 1114594, 846827))
+tbtest_n <- dim(tbtest_df)[1]
+
+test_that("Traitbank API works", {
+  skip_on_cran()
+  check_traitbank()
+
+  for (k in seq_len(tbtest_n)) {
+    get.out <- traitbank_GET(paste0(tburl(), tbtest_df[k, "pageid"]))
+    expect_is(get.out, "list", info = tbtest_df[k, "sciname"])
+    expect_true("item" %in% names(get.out), info = tbtest_df[k, "sciname"])
+    expect_true("@context" %in% names(get.out), info = tbtest_df[k, "sciname"])
+    expect_true("traits" %in% names(get.out$item), info = tbtest_df[k, "sciname"])
+  }
+})
+
+test_that("Basic search works", {
+  skip_on_cran()
+  check_traitbank()
+
+  for (k in seq_len(tbtest_n)) {
+    get.out <- traitbank_GET(paste0(tburl(), tbtest_df[k, "pageid"]))
+    expect_equal(get.out$item$`@id`, tbtest_df[k, "pageid"],
+      info = tbtest_df[k, "sciname"])
+    expect_equal(get.out$item$`dwc:taxonRank`, "species",
+      info = tbtest_df[k, "sciname"])
+    expect_true(grepl(tbtest_df[k, "sciname"], get.out$item$scientificName),
+      info = tbtest_df[k, "sciname"])
+  }
+})
+
+rm(tbtest_df, tbtest_n)


### PR DESCRIPTION
- addresses issue #79 

- function `trait_bank`:
    * checks for correct structure of returned object
    * prints message if structure mismatches expectation
    * always returns same object structure (potentially with empty
elements)

- unit tests:
    * function `check_traitbank`
    * file 'test-traitbank.R'


- this pull-request passes unit tests and is installable:

`devtools::test()`
> Loading traits
> Testing traits
> BETYdb tests: ....................
> eol's traitbank tests: .....................
> 
> DONE ============================================

`devtools::install()`
> Installing traits
> [...]
> 
> * installing *source* package ‘traits’ ...
> ** R
> ** data
> *** moving datasets to lazyload DB
> ** inst
> ** tests
> ** preparing package for lazy loading
> ** help
> *** installing help indices
> ** building package indices
> ** installing vignettes
> ** testing if installed package can be loaded
> * DONE (traits)
> Reloading installed traits
