### PR TITLE
BETY cleanup

### DIFF
--- a/R/betydb.R
+++ b/R/betydb.R
@@ -111,6 +111,8 @@ makepropname <- function(name, api_version){
 #' Default is \code{options("betydb_api_version")} if set, otherwise  "v0".
 #' @param betyurl (string) url to target instance of betydb.
 #' Default is \code{options("betydb_url")} if set, otherwise "https:/www.betydb.org/"
+#' @param user,pwd (character) A user name and password. Use a user/pwd combo or an API key.
+#' Save in your \code{.Rprofile} file as \code{options(betydb_user = "yournamehere")} and \code{options(betydb_pwd = "yourpasswordhere")}. Optional
 #'
 #' @return A data.frame with attributes containing request metadata, or NULL if the query produced no results
 #'
@@ -142,7 +144,7 @@ makepropname <- function(name, api_version){
 #' # [1] "Miscanthus"
 #' }
 #'
-betydb_query <- function(..., table = "search", key = NULL, api_version = NULL, betyurl = NULL){
+betydb_query <- function(..., table = "search", key = NULL, api_version = NULL, betyurl = NULL, user = NULL, pwd = NULL){
   url <- makeurl(table = table, fmt = "json", api_version = api_version, betyurl = betyurl)
   propname <- makepropname(table, api_version)
   betydb_GET(url, args = list(...), key = key, user = NULL, pwd = NULL, which = propname)
@@ -211,7 +213,7 @@ betydb_http <- function(url, args = list(), key = NULL, user = NULL, pwd = NULL,
 #' @export
 #' @rdname betydb
 #' @param table (character) Name of the database table with which this ID is associated.
-betydb_record <- function(id, table, api_version = NULL, betyurl = NULL, fmt = "json", ...){
+betydb_record <- function(id, table, api_version = NULL, betyurl = NULL, fmt = NULL, key = NULL, user = NULL, pwd = NULL, ...){
   args = list(...)
   betydb_GET(makeurl(table, id, fmt, api_version, betyurl), args, which = makepropname(table, api_version))
 }

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -92,6 +92,9 @@ makeurl <- function(table, id = NULL, fmt = "json", api_version = NULL, betyurl 
 # FIXME: not a very future-proof approach.
 # Would be nice if we could query the API itself for these.
 makepropname <- function(name, api_version){
+  if (is.null(api_version)) {
+    api_version <- getOption("betydb_api_version", default = "v0")
+  }
   switch(
     name,
     search = "traits_and_yields_view",

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -2,7 +2,6 @@
 #'
 #' @name betydb
 #'
-#' @param query Query terms
 #' @param genus (character) A genus name. Optional
 #' @param species (character) A specific epithet. Optional
 #' @param id (integer) One or more ids for a species, site, variable, etc.
@@ -64,12 +63,7 @@
 #' ## Site information
 #' betydb_site(id = 795)
 #' }
-
-#' @export
-#' @rdname betydb
-betydb_search <- function(query = "Maple SLA", ...){
-  betydb_query(search = query, table = "search", ...)
-}
+NULL
 
 makeurl <- function(table, id = NULL, fmt = "json", api_version = NULL, betyurl = NULL){
   if (is.null(betyurl)) {
@@ -109,6 +103,7 @@ makepropname <- function(name, api_version){
 #' @export
 #' @param ... (named character) Columns to query, as key="value" pairs. Note that betydb_query passes these along to BETY with no check whether the requested keys exist in the specified table.
 #' @param table (character) The name of the database table to query, or "search" (the default) for the traits and yields view
+#' @param query (character) A string containing one or more words to be queried across all columns of the "search" table.
 #' @param key (character) An API key. Use this or user/pwd combo.
 #' Save in your \code{.Rprofile} file as \code{options(betydb_key = "your40digitkey")}. Optional
 #' @param api_version (character) Which version of the BETY API should we query? One of "v0" or "beta".
@@ -150,6 +145,12 @@ betydb_query <- function(..., table = "search", key = NULL, api_version = NULL, 
   url <- makeurl(table = table, fmt = "json", api_version = api_version, betyurl = betyurl)
   propname <- makepropname(table, api_version)
   betydb_GET(url, args = list(...), key = key, user = NULL, pwd = NULL, which = propname)
+}
+
+#' @export
+#' @rdname betydb_query
+betydb_search <- function(query = "Maple SLA", ...){
+  betydb_query(search = query, table = "search", ...)
 }
 
 betydb_GET <- function(url, args = list(), key = NULL, user = NULL, pwd = NULL, which, ...){

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -71,7 +71,7 @@ betydb_search <- function(query = "Maple SLA", ...){
   betydb_query(search = query, table = "search", ...)
 }
 
-makeurl <- function(x, fmt, api_version = NULL, include = NULL, betyurl = NULL){
+makeurl <- function(table, id=NULL, fmt="json", api_version = NULL, betyurl = NULL){
   if (is.null(betyurl)) {
     betyurl <- getOption("betydb_url", default = "https://www.betydb.org/")
   }
@@ -80,8 +80,11 @@ makeurl <- function(x, fmt, api_version = NULL, include = NULL, betyurl = NULL){
   }
   api_string <- if (api_version == "v0") { "" } else { paste0("api/", api_version, "/")}
   fmt <- match.arg(fmt, c("json","xml","csv"))
-  url <- paste0(betyurl, api_string, paste0(x, "."), fmt)
-  return(url)
+  betyurl = sub("/*$", "/", betyurl)
+  if (!is.null(id)){
+    return(paste0(betyurl, api_string, table, "/", id, ".", fmt))
+  }
+  paste0(betyurl, api_string, paste0(table, "."), fmt)
 }
 
 # Look up property name (usually singular)
@@ -141,7 +144,7 @@ makepropname <- function(name, api_version){
 #' }
 #'
 betydb_query <- function(..., table = "search", key = NULL, api_version = NULL, betyurl = NULL){
-  url <- makeurl(x=table, fmt="json", api_version=api_version, betyurl=betyurl)
+  url <- makeurl(table=table, fmt="json", api_version=api_version, betyurl=betyurl)
   propname <- makepropname(table, api_version)
   betydb_GET(url, args=list(...), key=key, user=NULL, pwd=NULL, which=propname)
 }
@@ -205,34 +208,34 @@ betydb_http <- function(url, args = list(), key=NULL, user=NULL, pwd=NULL, ...){
 #' @param table (character) Name of the database table with which this ID is associated.
 betydb_record <- function(id, table, api_version = NULL, betyurl = NULL, fmt = "json", ...){
   args = list(...)
-  betydb_GET(makeidurl(table, id, fmt, api_version, betyurl), args, which=makepropname(table, api_version))
+  betydb_GET(makeurl(table, id, fmt, api_version, betyurl), args, which=makepropname(table, api_version))
 }
 
 #' @export
 #' @rdname betydb
 betydb_trait <- function(id, genus = NULL, species = NULL, api_version = NULL, betyurl = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL, ...){
   args <- traitsc(list(species.genus = genus, species.species = species))
-  betydb_GET(makeidurl("variables", id, fmt, api_version, betyurl), args, key, user, pwd, "variable", ...)
+  betydb_GET(makeurl("variables", id, fmt, api_version, betyurl), args, key, user, pwd, "variable", ...)
 }
 
 #' @export
 #' @rdname betydb
 betydb_specie <- function(id, genus = NULL, species = NULL, api_version = NULL, betyurl = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL, ...){
   args <- traitsc(list(genus = genus, species = species))
-  betydb_GET(makeidurl("species", id, fmt, api_version, betyurl), args, key, user, pwd, "specie", ...)
+  betydb_GET(makeurl("species", id, fmt, api_version, betyurl), args, key, user, pwd, "specie", ...)
 }
 
 #' @export
 #' @rdname betydb
 betydb_citation <- function(id, genus = NULL, species = NULL, api_version = NULL, betyurl = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL, ...){
   args <- traitsc(list(genus = genus, species = species))
-  betydb_GET(makeidurl("citations", id, fmt, api_version, betyurl), args, key, user, pwd, "citation", ...)
+  betydb_GET(makeurl("citations", id, fmt, api_version, betyurl), args, key, user, pwd, "citation", ...)
 }
 
 #' @export
 #' @rdname betydb
 betydb_site <- function(id, api_version = NULL, betyurl = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL, ...){
-  betydb_GET(makeidurl("sites", id, fmt, api_version, betyurl), args = NULL, key, user, pwd, "site", ...)
+  betydb_GET(makeurl("sites", id, fmt, api_version, betyurl), args = NULL, key, user, pwd, "site", ...)
 }
 
 
@@ -258,18 +261,6 @@ betydb_auth <- function(user,pwd,key){
   auth
 }
 
-makeidurl <- function(x, id, fmt, api_version = NULL, betyurl = NULL){
-  if (is.null(betyurl)) {
-    betyurl <- getOption("betydb_url", default = "https://www.betydb.org/")
-  }
-  if (is.null(api_version)) {
-    api_version <- getOption("betydb_api_version", default = "v0")
-  }
-  fmt <- match.arg(fmt, c("json","xml","csv"))
-  api = if (api_version == "v0") { "" } else { paste0("api/", api_version, "/") }
-  sprintf("%s%s%s/%s.%s", betyurl, api, x, id, fmt)
-}
-
 warn <- "Supply either api key, or user name/password combo"
 
 
@@ -284,5 +275,5 @@ warn <- "Supply either api key, or user name/password combo"
 ## betydb_yield
 # betydb_yield <- function(id, genus = NULL, species = NULL, fmt = "json", key=NULL, user=NULL, pwd=NULL, ...){
 #   args <- traitsc(list(genus = genus, species = species))
-#   betydb_GET2(makeidurl("yields", id, fmt), args, key, user, pwd, "yield", ...)
+#   betydb_GET2(makeurl("yields", id, fmt), args, key, user, pwd, "yield", ...)
 # }

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -104,6 +104,7 @@ makepropname <- function(name, api_version){
 #' @param ... (named character) Columns to query, as key="value" pairs. Note that betydb_query passes these along to BETY with no check whether the requested keys exist in the specified table.
 #' @param table (character) The name of the database table to query, or "search" (the default) for the traits and yields view
 #' @param query (character) A string containing one or more words to be queried across all columns of the "search" table.
+#' @param include_unchecked (logical) Include results that have not been quality checked? Applies only to tables with a "checked" column: "search", "traits", "yields". Default is to exclude unchecked values.
 #' @param key (character) An API key. Use this or user/pwd combo.
 #' Save in your \code{.Rprofile} file as \code{options(betydb_key = "your40digitkey")}. Optional
 #' @param api_version (character) Which version of the BETY API should we query? One of "v0" or "beta".
@@ -149,8 +150,8 @@ betydb_query <- function(..., table = "search", key = NULL, api_version = NULL, 
 
 #' @export
 #' @rdname betydb_query
-betydb_search <- function(query = "Maple SLA", ...){
-  betydb_query(search = query, table = "search", ...)
+betydb_search <- function(query = "Maple SLA", ..., include_unchecked = NULL){
+  betydb_query(search = query, table = "search", include_unchecked = include_unchecked, ...)
 }
 
 betydb_GET <- function(url, args = list(), key = NULL, user = NULL, pwd = NULL, which, ...){

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -44,7 +44,7 @@
 #' However, plural functions like \code{betydb_traits} accept query parameters, but not
 #' ids, and always return a single data.frame.
 #'
-#' \code{betydb_search("Search terms", ...)} is a convenience wrapper that passes all further arguments to \code{\link{betydb_query}(table="search", search="Search terms", ...)}. See there for details on possible arguments.
+#' \code{betydb_search("Search terms", ...)} is a convenience wrapper that passes all further arguments to \code{\link{betydb_query}(table = "search", search = "Search terms", ...)}. See there for details on possible arguments.
 #'
 #' @examples \dontrun{
 #' # General Search
@@ -71,7 +71,7 @@ betydb_search <- function(query = "Maple SLA", ...){
   betydb_query(search = query, table = "search", ...)
 }
 
-makeurl <- function(table, id=NULL, fmt="json", api_version = NULL, betyurl = NULL){
+makeurl <- function(table, id = NULL, fmt = "json", api_version = NULL, betyurl = NULL){
   if (is.null(betyurl)) {
     betyurl <- getOption("betydb_url", default = "https://www.betydb.org/")
   }
@@ -95,7 +95,7 @@ makepropname <- function(name, api_version){
   switch(
     name,
     search = "traits_and_yields_view",
-    species = if(api_version=="v0"){ "specie" }else{ "species" },
+    species = if (api_version == "v0"){ "specie" }else{ "species" },
     entities = "entity",
     sub("s$", "", name)
   )
@@ -121,22 +121,22 @@ makepropname <- function(name, api_version){
 #'
 #' @examples \dontrun{
 #' # literal vs regular expression vs anchored regular expression:
-#' betydb_query(units="Mg", table="variables")
+#' betydb_query(units = "Mg", table = "variables")
 #' # NULL
-#' betydb_query(units="Mg/ha", table="variables") %>% select(name) %>% c()
+#' betydb_query(units = "Mg/ha", table = "variables") %>% select(name) %>% c()
 #' # $name
 #' # [1] "a_biomass"                  "root_live_biomass"
 #' # [3] "leaf_dead_biomass_in_Mg_ha" "SDM"
 #'
-#' betydb_query(genus="Miscanthus", table="species") %>% nrow()
+#' betydb_query(genus = "Miscanthus", table = "species") %>% nrow()
 #' # [1] 10
-#' (betydb_query(genus="~misc", table="species", api_version="beta")
+#' (betydb_query(genus = "~misc", table = "species", api_version = "beta")
 #'  %>% select(genus)
 #'  %>% unique() %>% c())
 #' # $genus
 #' # [1] "Platymiscium" "Miscanthus"   "Dermiscellum"
 #'
-#' (betydb_query(genus="~^misc", table="species", api_version="beta")
+#' (betydb_query(genus = "~^misc", table = "species", api_version = "beta")
 #'  %>% select(genus)
 #'  %>% unique() %>% c())
 #' # $genus
@@ -144,9 +144,9 @@ makepropname <- function(name, api_version){
 #' }
 #'
 betydb_query <- function(..., table = "search", key = NULL, api_version = NULL, betyurl = NULL){
-  url <- makeurl(table=table, fmt="json", api_version=api_version, betyurl=betyurl)
+  url <- makeurl(table = table, fmt = "json", api_version = api_version, betyurl = betyurl)
   propname <- makepropname(table, api_version)
-  betydb_GET(url, args=list(...), key=key, user=NULL, pwd=NULL, which=propname)
+  betydb_GET(url, args = list(...), key = key, user = NULL, pwd = NULL, which = propname)
 }
 
 betydb_GET <- function(url, args = list(), key = NULL, user = NULL, pwd = NULL, which, ...){
@@ -178,10 +178,10 @@ betydb_GET <- function(url, args = list(), key = NULL, user = NULL, pwd = NULL, 
   res
 }
 
-betydb_http <- function(url, args = list(), key=NULL, user=NULL, pwd=NULL, ...){
+betydb_http <- function(url, args = list(), key = NULL, user = NULL, pwd = NULL, ...){
   auth <- betydb_auth(user, pwd, key)
 
-  if (!grepl("/api/", url, fixed=TRUE)) {
+  if (!grepl("/api/", url, fixed = TRUE)) {
     # no API string means we're using the v0 API and must insert cross-table joins to allow searching.
     # TODO: Remove this block when expiring v0 support.
     includes <- list(`include[]=` = ifelse(any(grepl('species', names(args))), "specie", ''),
@@ -208,7 +208,7 @@ betydb_http <- function(url, args = list(), key=NULL, user=NULL, pwd=NULL, ...){
 #' @param table (character) Name of the database table with which this ID is associated.
 betydb_record <- function(id, table, api_version = NULL, betyurl = NULL, fmt = "json", ...){
   args = list(...)
-  betydb_GET(makeurl(table, id, fmt, api_version, betyurl), args, which=makepropname(table, api_version))
+  betydb_GET(makeurl(table, id, fmt, api_version, betyurl), args, which = makepropname(table, api_version))
 }
 
 #' @export
@@ -255,8 +255,8 @@ betydb_auth <- function(user,pwd,key){
   if (is.null(c(auth$key, auth$user, auth$pwd))) {
     # If no auth of any kind provided, use the ropensci-traits API key.
     # TODO: Are there implementations that accept password but not key? If so:
-    # auth <- list(user <- 'ropensci-traits', pwd <- 'ropensci', key=NULL)
-    auth$key="eI6TMmBl3IAb7v4ToWYzR0nZYY07shLiCikvT6Lv"
+    # auth <- list(user <- 'ropensci-traits', pwd <- 'ropensci', key = NULL)
+    auth$key = "eI6TMmBl3IAb7v4ToWYzR0nZYY07shLiCikvT6Lv"
   }
   auth
 }
@@ -266,14 +266,14 @@ warn <- "Supply either api key, or user name/password combo"
 
 # functions that dont work ------------------------------
 ## betydb_traits
-# betydb_traits <- function(genus = NULL, species = NULL, trait = NULL, author = NULL, fmt = "json", key=NULL, user=NULL, pwd=NULL, ...){
+# betydb_traits <- function(genus = NULL, species = NULL, trait = NULL, author = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL, ...){
 #   args <- traitsc(list(species.genus = genus, species.species = species, variables.name = trait))
 #   url <- makeurl("traits", fmt)
 #   betydb_GET(url = url, args, key, user, pwd, "trait", ...)
 # }
 
 ## betydb_yield
-# betydb_yield <- function(id, genus = NULL, species = NULL, fmt = "json", key=NULL, user=NULL, pwd=NULL, ...){
+# betydb_yield <- function(id, genus = NULL, species = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL, ...){
 #   args <- traitsc(list(genus = genus, species = species))
 #   betydb_GET2(makeurl("yields", id, fmt), args, key, user, pwd, "yield", ...)
 # }

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -45,6 +45,8 @@
 #'
 #' \code{betydb_search("Search terms", ...)} is a convenience wrapper that passes all further arguments to \code{\link{betydb_query}(table = "search", search = "Search terms", ...)}. See there for details on possible arguments.
 #'
+#' @seealso \code{\link{betydb_query}}
+#'
 #' @examples \dontrun{
 #' # General Search
 #' out <- betydb_search(query = "Switchgrass Yield")

--- a/man/betydb.Rd
+++ b/man/betydb.Rd
@@ -112,4 +112,7 @@ betydb_site(id = 795)
 API documentation \url{https://pecan.gitbooks.io/betydb-data-access/content/API.html} and
 https://www.betydb.org/api/docs
 }
+\seealso{
+\code{\link{betydb_query}}
+}
 

--- a/man/betydb.Rd
+++ b/man/betydb.Rd
@@ -9,8 +9,8 @@
 \alias{betydb_trait}
 \title{Search for traits from BETYdb}
 \usage{
-betydb_record(id, table, api_version = NULL, betyurl = NULL, fmt = "json",
-  ...)
+betydb_record(id, table, api_version = NULL, betyurl = NULL, fmt = NULL,
+  key = NULL, user = NULL, pwd = NULL, ...)
 
 betydb_trait(id, genus = NULL, species = NULL, api_version = NULL,
   betyurl = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL,
@@ -39,17 +39,17 @@ betydb_site(id, api_version = NULL, betyurl = NULL, fmt = "json",
 \item{fmt}{(character) Format to return data in, one of json, xml, csv. Only json
 currently supported.}
 
-\item{...}{Curl options passed on to \code{\link[httr]{GET}}. Optional}
-
-\item{genus}{(character) A genus name. Optional}
-
-\item{species}{(character) A specific epithet. Optional}
-
 \item{key}{(character) An API key. Use this or user/pwd combo. Save in your
 \code{.Rprofile} file as \code{options(betydb_key = "your40digitkey")}. Optional}
 
 \item{user, pwd}{(character) A user name and password. Use a user/pwd combo or an API key.
 Save in your \code{.Rprofile} file as \code{options(betydb_user = "yournamehere")} and \code{options(betydb_pwd = "yourpasswordhere")}. Optional}
+
+\item{...}{Curl options passed on to \code{\link[httr]{GET}}. Optional}
+
+\item{genus}{(character) A genus name. Optional}
+
+\item{species}{(character) A specific epithet. Optional}
 }
 \description{
 Search for traits from BETYdb

--- a/man/betydb.Rd
+++ b/man/betydb.Rd
@@ -4,14 +4,11 @@
 \alias{betydb}
 \alias{betydb_citation}
 \alias{betydb_record}
-\alias{betydb_search}
 \alias{betydb_site}
 \alias{betydb_specie}
 \alias{betydb_trait}
 \title{Search for traits from BETYdb}
 \usage{
-betydb_search(query = "Maple SLA", ...)
-
 betydb_record(id, table, api_version = NULL, betyurl = NULL, fmt = "json",
   ...)
 
@@ -31,10 +28,6 @@ betydb_site(id, api_version = NULL, betyurl = NULL, fmt = "json",
   key = NULL, user = NULL, pwd = NULL, ...)
 }
 \arguments{
-\item{query}{Query terms}
-
-\item{...}{Curl options passed on to \code{\link[httr]{GET}}. Optional}
-
 \item{id}{(integer) One or more ids for a species, site, variable, etc.}
 
 \item{table}{(character) Name of the database table with which this ID is associated.}
@@ -45,6 +38,8 @@ betydb_site(id, api_version = NULL, betyurl = NULL, fmt = "json",
 
 \item{fmt}{(character) Format to return data in, one of json, xml, csv. Only json
 currently supported.}
+
+\item{...}{Curl options passed on to \code{\link[httr]{GET}}. Optional}
 
 \item{genus}{(character) A genus name. Optional}
 

--- a/man/betydb.Rd
+++ b/man/betydb.Rd
@@ -12,23 +12,23 @@
 \usage{
 betydb_search(query = "Maple SLA", ...)
 
-betydb_record(id, table, api_version = "v0",
-  betyurl = "https://www.betydb.org/", fmt = "json", ...)
+betydb_record(id, table, api_version = NULL, betyurl = NULL, fmt = "json",
+  ...)
 
-betydb_trait(id, genus = NULL, species = NULL, api_version = "v0",
-  betyurl = "https://www.betydb.org/", fmt = "json", key = NULL,
-  user = NULL, pwd = NULL, ...)
+betydb_trait(id, genus = NULL, species = NULL, api_version = NULL,
+  betyurl = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL,
+  ...)
 
-betydb_specie(id, genus = NULL, species = NULL, api_version = "v0",
-  betyurl = "https://www.betydb.org/", fmt = "json", key = NULL,
-  user = NULL, pwd = NULL, ...)
+betydb_specie(id, genus = NULL, species = NULL, api_version = NULL,
+  betyurl = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL,
+  ...)
 
-betydb_citation(id, genus = NULL, species = NULL, api_version = "v0",
-  betyurl = "https://www.betydb.org/", fmt = "json", key = NULL,
-  user = NULL, pwd = NULL, ...)
+betydb_citation(id, genus = NULL, species = NULL, api_version = NULL,
+  betyurl = NULL, fmt = "json", key = NULL, user = NULL, pwd = NULL,
+  ...)
 
-betydb_site(id, api_version = "v0", betyurl = "https://www.betydb.org/",
-  fmt = "json", key = NULL, user = NULL, pwd = NULL, ...)
+betydb_site(id, api_version = NULL, betyurl = NULL, fmt = "json",
+  key = NULL, user = NULL, pwd = NULL, ...)
 }
 \arguments{
 \item{query}{Query terms}
@@ -39,9 +39,9 @@ betydb_site(id, api_version = "v0", betyurl = "https://www.betydb.org/",
 
 \item{table}{(character) Name of the database table with which this ID is associated.}
 
-\item{api_version}{(character) Which version of the BETY API should we query? One of "v0" or "beta". Currently defaults to "v0".}
+\item{api_version}{(character) Which version of the BETY API should we query? One of "v0" or "beta". Default is \code{options("betydb_api_version")} if set, otherwise  "v0".}
 
-\item{betyurl}{(string) url to target instance of betydb. Default is https:/www.betydb.org/}
+\item{betyurl}{(string) url to target instance of betydb. Default is \code{options("betydb_url")} if set, otherwise "https:/www.betydb.org/"}
 
 \item{fmt}{(character) Format to return data in, one of json, xml, csv. Only json
 currently supported.}
@@ -51,10 +51,10 @@ currently supported.}
 \item{species}{(character) A specific epithet. Optional}
 
 \item{key}{(character) An API key. Use this or user/pwd combo. Save in your
-\code{.Rprofile} file as \code{betydb_key}. Optional}
+\code{.Rprofile} file as \code{options(betydb_key = "your40digitkey")}. Optional}
 
 \item{user, pwd}{(character) A user name and password. Use a user/pwd combo or an API key.
-Save in your \code{.Rprofile} file as \code{betydb_user} and \code{betydb_pwd}. Optional}
+Save in your \code{.Rprofile} file as \code{options(betydb_user = "yournamehere")} and \code{options(betydb_pwd = "yourpasswordhere")}. Optional}
 }
 \description{
 Search for traits from BETYdb

--- a/man/betydb.Rd
+++ b/man/betydb.Rd
@@ -91,7 +91,7 @@ and return a list of variable outputs depending on the inputs.
 However, plural functions like \code{betydb_traits} accept query parameters, but not
 ids, and always return a single data.frame.
 
-\code{betydb_search("Search terms", ...)} is a convenience wrapper that passes all further arguments to \code{\link{betydb_query}(table="search", search="Search terms", ...)}. See there for details on possible arguments.
+\code{betydb_search("Search terms", ...)} is a convenience wrapper that passes all further arguments to \code{\link{betydb_query}(table = "search", search = "Search terms", ...)}. See there for details on possible arguments.
 }
 \examples{
 \dontrun{

--- a/man/betydb_query.Rd
+++ b/man/betydb_query.Rd
@@ -4,20 +4,22 @@
 \alias{betydb_query}
 \title{Query a BETY table}
 \usage{
-betydb_query(..., table = "search", key = NULL, api_version = "v0",
-  betyurl = "https://www.betydb.org/")
+betydb_query(..., table = "search", key = NULL, api_version = NULL,
+  betyurl = NULL)
 }
 \arguments{
 \item{...}{(named character) Columns to query, as key="value" pairs. Note that betydb_query passes these along to BETY with no check whether the requested keys exist in the specified table.}
 
 \item{table}{(character) The name of the database table to query, or "search" (the default) for the traits and yields view}
 
-\item{key}{(character) An API key. Use this or user/pwd combo. Save in your
-\code{.Rprofile} file as \code{betydb_key}. Optional}
+\item{key}{(character) An API key. Use this or user/pwd combo.
+Save in your \code{.Rprofile} file as \code{options(betydb_key = "your40digitkey")}. Optional}
 
-\item{api_version}{(character) Which version of the betydb api to use? Optional, defaults to 'v0'}
+\item{api_version}{(character) Which version of the BETY API should we query? One of "v0" or "beta".
+Default is \code{options("betydb_api_version")} if set, otherwise  "v0".}
 
-\item{betyurl}{(string) url to target instance of betydb. Default is https:/www.betydb.org/}
+\item{betyurl}{(string) url to target instance of betydb.
+Default is \code{options("betydb_url")} if set, otherwise "https:/www.betydb.org/"}
 }
 \value{
 A data.frame with attributes containing request metadata, or NULL if the query produced no results

--- a/man/betydb_query.Rd
+++ b/man/betydb_query.Rd
@@ -2,10 +2,13 @@
 % Please edit documentation in R/betydb.R
 \name{betydb_query}
 \alias{betydb_query}
+\alias{betydb_search}
 \title{Query a BETY table}
 \usage{
 betydb_query(..., table = "search", key = NULL, api_version = NULL,
   betyurl = NULL)
+
+betydb_search(query = "Maple SLA", ...)
 }
 \arguments{
 \item{...}{(named character) Columns to query, as key="value" pairs. Note that betydb_query passes these along to BETY with no check whether the requested keys exist in the specified table.}
@@ -20,6 +23,8 @@ Default is \code{options("betydb_api_version")} if set, otherwise  "v0".}
 
 \item{betyurl}{(string) url to target instance of betydb.
 Default is \code{options("betydb_url")} if set, otherwise "https:/www.betydb.org/"}
+
+\item{query}{(character) A string containing one or more words to be queried across all columns of the "search" table.}
 }
 \value{
 A data.frame with attributes containing request metadata, or NULL if the query produced no results

--- a/man/betydb_query.Rd
+++ b/man/betydb_query.Rd
@@ -6,7 +6,7 @@
 \title{Query a BETY table}
 \usage{
 betydb_query(..., table = "search", key = NULL, api_version = NULL,
-  betyurl = NULL)
+  betyurl = NULL, user = NULL, pwd = NULL)
 
 betydb_search(query = "Maple SLA", ..., include_unchecked = NULL)
 }
@@ -23,6 +23,9 @@ Default is \code{options("betydb_api_version")} if set, otherwise  "v0".}
 
 \item{betyurl}{(string) url to target instance of betydb.
 Default is \code{options("betydb_url")} if set, otherwise "https:/www.betydb.org/"}
+
+\item{user, pwd}{(character) A user name and password. Use a user/pwd combo or an API key.
+Save in your \code{.Rprofile} file as \code{options(betydb_user = "yournamehere")} and \code{options(betydb_pwd = "yourpasswordhere")}. Optional}
 
 \item{query}{(character) A string containing one or more words to be queried across all columns of the "search" table.}
 

--- a/man/betydb_query.Rd
+++ b/man/betydb_query.Rd
@@ -34,22 +34,22 @@ If no filters are specified, retrieves the whole table. In API versions that sup
 \examples{
 \dontrun{
 # literal vs regular expression vs anchored regular expression:
-betydb_query(units="Mg", table="variables")
+betydb_query(units = "Mg", table = "variables")
 # NULL
-betydb_query(units="Mg/ha", table="variables") \%>\% select(name) \%>\% c()
+betydb_query(units = "Mg/ha", table = "variables") \%>\% select(name) \%>\% c()
 # $name
 # [1] "a_biomass"                  "root_live_biomass"
 # [3] "leaf_dead_biomass_in_Mg_ha" "SDM"
 
-betydb_query(genus="Miscanthus", table="species") \%>\% nrow()
+betydb_query(genus = "Miscanthus", table = "species") \%>\% nrow()
 # [1] 10
-(betydb_query(genus="~misc", table="species", api_version="beta")
+(betydb_query(genus = "~misc", table = "species", api_version = "beta")
  \%>\% select(genus)
  \%>\% unique() \%>\% c())
 # $genus
 # [1] "Platymiscium" "Miscanthus"   "Dermiscellum"
 
-(betydb_query(genus="~^misc", table="species", api_version="beta")
+(betydb_query(genus = "~^misc", table = "species", api_version = "beta")
  \%>\% select(genus)
  \%>\% unique() \%>\% c())
 # $genus

--- a/man/betydb_query.Rd
+++ b/man/betydb_query.Rd
@@ -8,7 +8,7 @@
 betydb_query(..., table = "search", key = NULL, api_version = NULL,
   betyurl = NULL)
 
-betydb_search(query = "Maple SLA", ...)
+betydb_search(query = "Maple SLA", ..., include_unchecked = NULL)
 }
 \arguments{
 \item{...}{(named character) Columns to query, as key="value" pairs. Note that betydb_query passes these along to BETY with no check whether the requested keys exist in the specified table.}
@@ -25,6 +25,8 @@ Default is \code{options("betydb_api_version")} if set, otherwise  "v0".}
 Default is \code{options("betydb_url")} if set, otherwise "https:/www.betydb.org/"}
 
 \item{query}{(character) A string containing one or more words to be queried across all columns of the "search" table.}
+
+\item{include_unchecked}{(logical) Include results that have not been quality checked? Applies only to tables with a "checked" column: "search", "traits", "yields". Default is to exclude unchecked values.}
 }
 \value{
 A data.frame with attributes containing request metadata, or NULL if the query produced no results

--- a/man/ncbi_byname.Rd
+++ b/man/ncbi_byname.Rd
@@ -21,6 +21,8 @@ in the same genus as the one searched for. If \code{FALSE}, returns nothing if n
 found.}
 
 \item{verbose}{(logical) If \code{TRUE} (default), informative messages printed.}
+
+\item{...}{Curl options passed on to \code{\link[httr]{GET}}}
 }
 \value{
 Data.frame of results.

--- a/tests/testthat/helper-traits.R
+++ b/tests/testthat/helper-traits.R
@@ -11,3 +11,20 @@ check_traitbank <- function(url){
     skip("eol's traitbank is offline.")
   }
 }
+
+#' Clean up any option changes to exactly match a previous state,
+#' *unsetting* any options not present in the old list. 
+#' @param old_opts a named list, probably created by a previous \code{old_opts <- options()}
+#' @return Invisibly, a list of the options changed and their values before resetting
+reset_opts <- function(old_opts){
+	cur_opts <- options()
+	unchanged_opts <- sapply(names(old_opts), function(x){ old_opts[x] %in% cur_opts[x] })
+	newly_set <- setdiff(names(cur_opts), names(old_opts))
+	nulls <- vector(mode = "list", length = length(newly_set))
+	names(nulls) <- newly_set
+	
+	reset_vals <- options(old_opts[!unchanged_opts])
+	removed_vals <- options(nulls)
+
+	invisible(c(reset_vals, removed_vals))
+}

--- a/tests/testthat/test-betydb.R
+++ b/tests/testthat/test-betydb.R
@@ -27,7 +27,7 @@ test_that("BETYdb beta API works", {
   check_betydb()
 
   betyurl <- "https://www.betydb.org/"
-  priors_url <- makeurl("priors", fmt = "json", betyurl = betyurl, api_version="beta")
+  priors_url <- makeurl("priors", fmt = "json", betyurl = betyurl, api_version = "beta")
   expect_equal(priors_url, paste0(betyurl, "api/beta/priors.json"))
 
   get.out <- GET(priors_url) # Priors is a small table
@@ -42,14 +42,14 @@ test_that("table to property name matching works", {
   getprop <- function(name){
     txt <- betydb_http(
       makeurl(name, fmt = "json", betyurl = "https://www.betydb.org/", api_version = "beta"),
-      args = list(limit=1),
+      args = list(limit = 1),
       key = NULL,
       user = NULL,
       pwd = NULL)
     names(jsonlite::fromJSON(txt, simplifyVector = TRUE, flatten = FALSE)$data)[[1]]
   }
   tablenames <- c("search", "species", "entities", "citations", "pfts")
-  expected_propnames <- sapply(tablenames, makepropname, api_version="beta")
+  expected_propnames <- sapply(tablenames, makepropname, api_version = "beta")
   got_propnames <- sapply(tablenames, getprop)
 
   expect_equal(got_propnames, expected_propnames)
@@ -103,11 +103,11 @@ test_that("URL & version options work", {
 
   options(betydb_url = "http://example.com/", betydb_api_version = "beta")
   expect_error(betydb_query(author = "Arundale", table = "citations"), "Not Found")
-  opt2 <- betydb_query(author = "Arundale", table = "citations", 
+  opt2 <- betydb_query(author = "Arundale", table = "citations",
     betyurl = "https://www.betydb.org/")
   opt3 <- betydb_query(author = "Arundale", table = "citations",
     betyurl = "https://www.betydb.org/", api_version = "v0")
-  
+
   expect_gt(ncol(opt2), ncol(opt3)) # new API returns more params
   expect_equal(opt2$id, opt3$id) # but both should find same IDs
   expect_equal(opt1, opt3)
@@ -117,13 +117,13 @@ test_that("betydb_query works", {
   skip_on_cran()
   check_betydb()
 
-  np <- betydb_query(distn="norm", table="priors")
+  np <- betydb_query(distn = "norm", table = "priors")
   expect_is(np, "data.frame")
   expect_is(np$distn, "character")
   expect_equal(length(unique(np$distn)), 1)
   expect_equal(unique(np$distn), "norm")
 
-  np_grass <- betydb_query(distn="norm", phylogeny="grass", table="priors")
+  np_grass <- betydb_query(distn = "norm", phylogeny = "grass", table = "priors")
   expect_true(all(np_grass$id %in% np$id))
 })
 
@@ -131,7 +131,7 @@ test_that("betydb_record works", {
   skip_on_cran()
   check_betydb()
 
-  rec <- betydb_record(id = 10, table="traits")
+  rec <- betydb_record(id = 10, table = "traits")
   expect_is(rec, "list")
   expect_is(rec$id, "integer")
   expect_equal(rec$id, 10)

--- a/tests/testthat/test-betydb.R
+++ b/tests/testthat/test-betydb.R
@@ -175,3 +175,14 @@ test_that("betydb_site works", {
   expect_is(dd, "list")
   expect_is(dd$city, "character")
 })
+
+test_that("include_unchecked works", {
+  skip_on_cran()
+  check_betydb()
+
+  q1 <- betydb_search(query = "maple SLA")
+  q2 <- betydb_search(query = "maple SLA", include_unchecked = TRUE)
+
+  expect_gt(nrow(q2), nrow(q1))
+  expect_true(all(q1$id %in% q2$id))
+})

--- a/vignettes/betydb.Rmd
+++ b/vignettes/betydb.Rmd
@@ -393,3 +393,71 @@ betydb_query(parama = "~0.0", table = 'priors', api_version="beta")
 ## #   updated_at <chr>, `number of associated pfts` <int>,
 ## #   view_url <chr>, edit_url <chr>
 ```
+
+## Changing which results you see
+
+There are three special query terms that can limit which matching rows are returned: `limit`, `offset`, and `include_unchecked`.
+
+### limit and offset
+
+These parameters apply to the beta API only. The v0 API always returns all rows that match your query. This can be slow for large result sets, so newer API versions provide control over the number of rows retrieved at a time. By default, the API will return no more than 200 results when `limit` is unset. If you're sure you want all results in one request, use `limit = "none"`.
+
+```r
+options(betydb_api_version="beta")
+
+sla <- betydb_search("Maple SLA")
+# Warning message:
+# In betydb_GET(url, args = list(...), key = key, user = NULL, pwd = NULL,  :
+#  The 40370-row result set exceeds the default 200 row limit.  Showing the first 200 results only.  Set an explicit limit to show more results.
+
+sla2 <- betydb_search("Maple SLA", limit=300)
+sla3 <- betydb_search("Maple SLA", limit=100, offset=200)
+identical(sla2$id, c(sla$id, sla3$id))
+# [1] TRUE
+```
+
+### include_unchecked
+
+By default, BETY only shows results that have been checked for quality by an administrator. However, the tables `search`, `traits`, and `yields` contain many observations that are not checked but may still be of scientific interest. To query all values, add  `include_unchecked="true"` to your query, then sort or filter the unchecked values as you see fit by using the flags in the `checked` column of the result.
+
+```r
+misc_dur_checked <- betydb_query(table="search", genus="Miscanthus", sitename="Durmersheim")
+misc_dur_checked %>% group_by(year) %>% summarize(n())
+# # A tibble: 3 × 2
+#    year `n()`
+#   <int> <int>
+# 1  1994     4
+# 2  1995    24
+# 3    NA     2
+
+misc_dur_all <- betydb_query(table="search", genus="Miscanthus", sitename="Durmersheim", include_unchecked=TRUE)
+misc_dur_all %>% group_by(year, checked) %>% summarize(n())
+# Source: local data frame [6 x 3]
+# Groups: year [?]
+#
+#    year checked `n()`
+#   <int>   <int> <int>
+# 1  1994       0     5
+# 2  1994       1     4
+# 3  1995       0    12
+# 4  1995       1    24
+# 5  1996       0     2
+# 6    NA       1     2
+```
+
+You can also query the `checked` column directly. This is possible even without `include_unchecked`, though in that case the result is predictable:
+
+```r
+betydb_search("Miscanthus Durmersheim", checked=0)
+# NULL
+betydb_search("Miscanthus Durmersheim", checked=0, include_unchecked=TRUE)
+# # A tibble: 19 × 36
+#    access_level      author checked citation_id citation_year
+# *         <int>       <chr>   <int>       <int>         <int>
+# 1             4 Lewandowski       0         158          1997
+# 2             4 Lewandowski       0         158          1997
+# 3             4 Lewandowski       0         158          1997
+# 4             4 Lewandowski       0         158          1997
+# 5             4 Lewandowski       0         158          1997
+# ...
+```


### PR DESCRIPTION
Dealing with bits from the BETY API version update that weren't finished in #82.

* [x] Read bety instance URL, API version, and key from options (probably closes #77)
   * [x] @dlebauer Does this usage work? We discussed it a bit in #82, but didn't make a firm decision. I went with `options("betydb_url")` etc over `list(url, version, key, ...)` because it appears to be more in line with how auth is handled in other ropensci packages.
    * [x] @sckott I'd appreciate a skeptical review of my test case. I wanted to ensure that all option changes get rolled back at the end of the `test_that`, which turns out to be more complicated than I expected. See any lurking bugs?
* [x] Document that `betydb_query` accepts `include_unchecked`, `limit`, and `offset` (#52 )
* [ ] Deprecate table-specific query functions (#26)?
    * As discussed in #84, `betydb_record` now provides a generic replacement, so `betydb_<table>(id)` is now ~equivalent to `betydb_record(id, table=<table>)`.
    * A possible argument for retention: Would these functions be the appropriate place to handle output standardization (#38)? Records queried through the beta API contain nested lists whose layout differs from one table to another, so maybe they become formatters: Have `betydb_<table>` call `betydb_record` to get the full possibly-nested list, then apply whatever table-specific formatting is needed to return a standardized dataframe.
