### PR TITLE
add Chris Black to authors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Authors@R: c(
     person("Zachary", "Foster", role = "aut"),
     person("Ignasi", "Bartomeus", role = "aut"),
     person("David", "LeBauer", role = "aut"),
+    person("Chris", "Black", role = "aut"),
     person("David", "Harris", role = "aut"),
     person("Rupert", "Collins", role = "ctb")
   )


### PR DESCRIPTION
## Description

added (Chris Black) (@infotroph) to author list based on contributions to the betydb interface 


## Related Issue

PRs #94, #88, #82 represent substantial contributions 
