### PR TITLE
Fixes ncbi_searcher error on some queries

### DIFF
--- a/R/ncbi_searcher.R
+++ b/R/ncbi_searcher.R
@@ -229,7 +229,11 @@ taxonomy <- function(zz) {
     out[[ uids[i] ]] <- xml2::xml_text(xml2::xml_find_all(xml, '//Item[@Name="ScientificName"]'))
   }
   for (i in seq_along(out)) {
-    taxids[grepl(names(out)[i], taxids)] <- out[[i]]
+    if (length(out[[i]]) == 0) {
+      taxids[grepl(names(out)[i], taxids)] <- NA_character_
+    } else {
+      taxids[grepl(names(out)[i], taxids)] <- out[[i]]
+    }
   }
   return(taxids)
 }


### PR DESCRIPTION

## Description

I was getting the following error with the current github and CRAN versions:

```r
> x <- traits::ncbi_searcher(id = "155619", fuzzy = TRUE)
Working on 155619...
...retrieving sequence IDs...
...retrieving available genes and their lengths...
Error in taxids[grepl(names(out)[i], taxids)] <- out[[i]] : 
  replacement has length zero
```

It was caused by an error being returned from the NCBI API instead of taxonomic information at this line:

https://github.com/ropensci/traits/blob/089094a07ba5722fbca964c99c618b13f7d68204/R/ncbi_searcher.R#L226

I am not sure why the error was occurring, but I changed the code so it returns `NA` in that case instead of failing. 
 
## Example

```r
x <- traits::ncbi_searcher(id = "155619", fuzzy = TRUE)
> dplyr::as_tibble(x)
# A tibble: 500 x 5
   taxon                    length gene_desc                                                                   acc_no   gi_no
 * <chr>                     <dbl> <chr>                                                                       <chr>    <dbl>
 1 Lanmaoa pseudosensibilis   941. Lanmaoa pseudosensibilis voucher Mushroom Observer #275044 large subunit r… MH244…  1.38e9
 2 Boletaceae sp.             991. Boletaceae sp. voucher Mushroom Observer #250391 large subunit ribosomal R… MH244…  1.38e9
 3 Boletaceae sp.             988. Boletaceae sp. voucher Mushroom Observer #248795 large subunit ribosomal R… MH244…  1.38e9
 4 Boletus separans           993. Boletus separans voucher Mushroom Observer #282660 large subunit ribosomal… MH244…  1.38e9
 5 Boletus subvelutipes       750. Boletus subvelutipes voucher Mushroom Observer #285181 internal transcribe… MH244…  1.38e9
 6 Boletus subvelutipes       979. Boletus subvelutipes voucher Mushroom Observer #285181 large subunit ribos… MH244…  1.38e9
 7 Boletaceae sp.             567. Boletaceae sp. voucher Mushroom Observer #215899 small subunit ribosomal R… MH244…  1.38e9
 8 Leccinum snellii           967. Leccinum snellii voucher Mushroom Observer #288473 large subunit ribosomal… MH238…  1.38e9
 9 Boletus vermiculosoides    607. Boletus vermiculosoides voucher Mushroom Observer #279688 internal transcr… MH238…  1.38e9
10 NA                         756. Gliophorus cf. psittacinus internal transcribed spacer 2 and large subunit… MH237…  1.38e9
# ... with 490 more rows
```
