### PR TITLE
add alias API version beta == v1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Species trait data from many different sources, including
     from the USDA plants database, data from 'EOL' 'Traitbank', 
     Coral traits data (<https://coraltraits.org>), 'Birdlife' International, 
     and more.
-Version: 0.4.0.9100
+Version: 0.4.1.9100
 Authors@R: c(
     person("Scott", "Chamberlain", role = c("aut", "cre"), email = "myrmecocystus@gmail.com"),
     person("Zachary", "Foster", role = "aut"),

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -175,7 +175,7 @@ betydb_GET <- function(url, args = list(), key = NULL, user = NULL, pwd = NULL,
   if(api_version == 'v0'){
     txt <- betydb_http(url, args, key, user, pwd, ...)
     lst <- jsonlite::fromJSON(txt, simplifyVector = TRUE, flatten = TRUE)
-  } else if (api_version == 'beta'){
+  } else if (api_version %in% c('beta', 'v1')){
 
     if(is.null(args$limit)) {
       args$limit <- 200

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -375,13 +375,6 @@ betydb_auth <- function(user,pwd,key){
     if (xor(is.null(user), is.null(pwd))) stop(warn, call. = FALSE)
     auth <- list(user = user, pwd = pwd, key = NULL)
   }
-
-  if (is.null(c(auth$key, auth$user, auth$pwd))) {
-    # If no auth of any kind provided, use the ropensci-traits API key.
-    # TODO: Are there implementations that accept password but not key? If so:
-    # auth <- list(user <- 'ropensci-traits', pwd <- 'ropensci', key = NULL)
-    auth$key = "eI6TMmBl3IAb7v4ToWYzR0nZYY07shLiCikvT6Lv"
-  }
   auth
 }
 

--- a/R/betydb.R
+++ b/R/betydb.R
@@ -365,7 +365,7 @@ betydb_experiment <- function(id, api_version = NULL, betyurl = NULL, fmt = "jso
 
 betydb_auth <- function(user,pwd,key){
   if (is.null(key) && is.null(user)) {
-    key <- getOption("betydb_key", NULL)
+    key <- getOption("betydb_key", '9999999999999999999999999999999999999999')
   }
   if (!is.null(key)) {
     auth <- list(key = key)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the last release I forgot to merge in this minor change.

We've created an v1 that will eventually replace our /beta endpoint. We currently maintain both for backward compatibility, but have started using v1 in our tutorials and documentation that were based on the terraref/traits fork. It would be nice to be able to write code that uses the v1 end point instead of the beta endpoint. 

Would it be possible to push this to CRAN as a v0.4.1 'hotfix' so that our current tutorials will work with the official version on cran?

## Example

This should work:

```r
options(
        betydb_url = "https://terraref.ncsa.illinois.edu/bety/",
        betydb_api_version = 'v1')
canopy_height <- betydb_search(trait     = "canopy_height",
                               sitename  = "~Season 6",
                               limit     = "1"
                               )
```
