### PR TITLE
Archive on Zenodo, add doi to README and CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -47,4 +47,29 @@ keywords:
 - r
 - r-package
 - rstats
-
+preferred-citation:
+  type: software
+  title: 'ropensci/traits: traits 0.5.1'
+  version: 0.5.1
+  authors:
+  - family-names: Chamberlain
+    given-names: Scott
+  - family-names: LeBauer
+    given-names: David
+  - family-names: Black
+    given-names: Chris
+  - family-names: Harris
+    given-names: David J.
+  - family-names: Bartomeus
+    given-names: Ignasi
+  - family-names: Foster
+    given-names: Zachary
+  - family-names: Salmon
+    given-names: Maëlle
+  - family-names: Heyek
+    given-names: Nick
+  - family-names: Collins
+    given-names: Rupert A.
+  doi: 10.5281/zenodo.11224037
+  url: https://doi.org/10.5281/zenodo.11224037
+  date-released: 2024-05-17

--- a/README.Rmd
+++ b/README.Rmd
@@ -10,11 +10,12 @@ knitr::opts_chunk$set(
 )
 ```
 
-[![cran checks](https://cranchecks.info/badges/worst/traits)](https://cranchecks.info/pkgs/traits)
+<!--[![cran checks](https://cranchecks.info/badges/worst/traits)](https://cranchecks.info/pkgs/traits)-->
 [![Build Status](https://travis-ci.org/ropensci/traits.svg?branch=master)](https://travis-ci.org/ropensci/traits)
 [![codecov](https://codecov.io/gh/ropensci/traits/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/traits)
 [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/traits)](https://github.com/r-hub/cranlogs.app)
 [![cran version](https://www.r-pkg.org/badges/version/traits)](https://CRAN.R-project.org/package=traits)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11224037.svg)](https://doi.org/10.5281/zenodo.11224037)
 
 R client for various sources of species trait data.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@ traits
 
 
 
-[![cran checks](https://cranchecks.info/badges/worst/traits)](https://cranchecks.info/pkgs/traits)
+<!--[![cran checks](https://cranchecks.info/badges/worst/traits)](https://cranchecks.info/pkgs/traits)-->
 [![Build Status](https://travis-ci.org/ropensci/traits.svg?branch=master)](https://travis-ci.org/ropensci/traits)
 [![codecov](https://codecov.io/gh/ropensci/traits/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/traits)
 [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/traits)](https://github.com/r-hub/cranlogs.app)
 [![cran version](https://www.r-pkg.org/badges/version/traits)](https://CRAN.R-project.org/package=traits)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11224037.svg)](https://doi.org/10.5281/zenodo.11224037)
 
 R client for various sources of species trait data.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Set up automatic archiving of releases on Zenodo
- Add CITATION.cff file
- add doi to README, CITATION.cff

