### PR TITLE
Changed 'country' to 'geo_loc_name' in `ncbi_byid()` #135

### DIFF
--- a/R/ncbi_byid.R
+++ b/R/ncbi_byid.R
@@ -69,7 +69,7 @@ ncbi_byid <- function(ids, format=NULL, verbose=TRUE) {
     voucher <- xml_helper(z, './/GBQualifier[GBQualifier_name = "specimen_voucher"]/GBQualifier_value')
     organelle <- xml_helper(z, './/GBQualifier[GBQualifier_name = "organelle"]/GBQualifier_value')
     lat.long <- xml_helper(z, './/GBQualifier[GBQualifier_name = "lat_lon"]/GBQualifier_value')
-    country <- xml_helper(z, './/GBQualifier[GBQualifier_name = "country"]/GBQualifier_value')
+    country <- xml_helper(z, './/GBQualifier[GBQualifier_name = "geo_loc_name"]/GBQualifier_value')
     first.author <- xml_helper(z, './/GBReference[GBReference_reference = "1"]/GBReference_authors/GBAuthor')
     paper.title <- xml_helper(z, './/GBReference[GBReference_reference = "1"]/GBReference_title')
     journal <- xml_helper(z, './/GBReference[GBReference_reference = "1"]/GBReference_journal')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NCBI changed the name of the 'country' field to 'geo_loc_name', so this has been updated in `ncbi_byid.R`.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

I added an issue at  #135

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

See #135